### PR TITLE
Add filter for changing cpt_acf_page_args

### DIFF
--- a/cpt-acf.php
+++ b/cpt-acf.php
@@ -71,6 +71,8 @@ function ctpacf_options_pages() {
 					'redirect'    => false
 				);
 
+				$cpt_acf_page = apply_filters( 'cpt_acf_page_args', $cpt_acf_page );
+
 				acf_add_options_page( $cpt_acf_page );
 
 			} // end if


### PR DESCRIPTION
This pull requests adds filter for developer to use for changing arguments passed to `acf_add_options_page()`
This is handy at least for the following reasons:
- Changing the menu name. For example "Event Archive" is not always the most intuitive name for options page
- Better support with Polylang. If I have for example two languages registered to my site: English and Finnish. With defaults ACF-CPT-Options-Pages actually creates three options page for one post type: English, Finnish and all. "All" -option page is mostly not needed, so it would be a good idea to change it to default language. With the help of this filter, developer can do just that. 