### PR TITLE
Remove underscores from menu label

### DIFF
--- a/class.acf-cpt-options-pages.php
+++ b/class.acf-cpt-options-pages.php
@@ -57,6 +57,7 @@ class ACFCPT_OptionsPages {
     }
 
     public function register_post_type_options_page($name, $cpt) {
+    	$name 		= ucfirst( str_replace('_', ' ', $name) );
         $cpt_id   = 'cpt_' . $cpt;
         $slug     = ($name !== $cpt ? '_' . strtolower(preg_replace('/[^a-zA-Z0-9_]/', '_', $name)) : '');
 

--- a/class.acf-cpt-options-pages.php
+++ b/class.acf-cpt-options-pages.php
@@ -57,7 +57,9 @@ class ACFCPT_OptionsPages {
     }
 
     public function register_post_type_options_page($name, $cpt) {
-    	$name 		= ucfirst( str_replace('_', ' ', $name) );
+    	$pt = get_post_type_object( $name );
+    	$post_type_label	= $pt->labels->singular_name;
+
         $cpt_id   = 'cpt_' . $cpt;
         $slug     = ($name !== $cpt ? '_' . strtolower(preg_replace('/[^a-zA-Z0-9_]/', '_', $name)) : '');
 
@@ -77,8 +79,8 @@ class ACFCPT_OptionsPages {
         );
 
         $cpt_acf_custom = array(
-	        'page_title'  => sprintf( __( '%s Options', CPT_ACF_DOMAIN ), ucfirst( $name ) ),
-	        'menu_title'  => sprintf( __( '%s Options', CPT_ACF_DOMAIN ), ucfirst( $name ) ),
+	        'page_title'  => sprintf( __( '%s Options', CPT_ACF_DOMAIN ), ucfirst( $post_type_label ) ),
+	        'menu_title'  => sprintf( __( '%s Options', CPT_ACF_DOMAIN ), ucfirst( $post_type_label ) ),
 	        'menu_slug'   => $slug .'-'. $cpt . '-options',
 	        'capability'  => 'edit_posts',
         );
@@ -98,6 +100,8 @@ class ACFCPT_OptionsPages {
 		unset($registered["0"]);
 
         foreach ( $registered as $k => $v ) {
+        	print_r($registered);
+
 			if(!is_array($v) && post_type_exists( $v )) {
 				$this->register_post_type_options_page($v, $v);
 			} else {

--- a/class.acf-cpt-options-pages.php
+++ b/class.acf-cpt-options-pages.php
@@ -100,8 +100,7 @@ class ACFCPT_OptionsPages {
 		unset($registered["0"]);
 
         foreach ( $registered as $k => $v ) {
-        	print_r($registered);
-
+        	
 			if(!is_array($v) && post_type_exists( $v )) {
 				$this->register_post_type_options_page($v, $v);
 			} else {


### PR DESCRIPTION
# If applied, this commit will resolve the issue of the underscores in the menu labels for archive options pages.