### PR TITLE
Add filter to get_post_types options

### DIFF
--- a/class.acf-cpt-options-pages.php
+++ b/class.acf-cpt-options-pages.php
@@ -44,10 +44,14 @@ class ACFCPT_OptionsPages {
     }
 
 	public function get_custom_post_types() {
-		return get_post_types(array(
-				'_builtin'    => false,
-				'has_archive' => true
-		));
+		$cpt_options = array(
+			'_builtin'    => false,
+			'has_archive' => true
+		);
+		
+		$cpt_options = apply_filters('cpt_options_post_types_params', $cpt_options);
+		
+		return get_post_types($cpt_options);
 	}
 
 	public function register_post_type_options_page($name, $cpt) {


### PR DESCRIPTION
Hi! Thanks for the great plugin. I often find myself wanting to add generic options related to the custom post type, but without an archive page. The default "has_archive" is good for most usage, but I had to manually edit this more often than I'd like to admit so I figured I would create a pull request and add a filter so people can remove the "has_archive" if needed.